### PR TITLE
Make targets active by default

### DIFF
--- a/loadbalancer/resource_target.go
+++ b/loadbalancer/resource_target.go
@@ -94,7 +94,7 @@ func resourceTarget() *schema.Resource {
 			"active": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  false,
+				Default:  true,
 			},
 		},
 	}


### PR DESCRIPTION
Targets should be active by default if the `active` attribute isn't set to required, otherwise it's easy to miss.